### PR TITLE
Fix working error under Firefox

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -3,7 +3,7 @@
 	<head>
 
 		<title>hastebin</title>
-
+    		<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
 		<link rel="stylesheet" type="text/css" href="solarized_dark.css"/>
 		<link rel="stylesheet" type="text/css" href="application.css"/>
 

--- a/static/index.html
+++ b/static/index.html
@@ -3,7 +3,7 @@
 	<head>
 
 		<title>hastebin</title>
-    		<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+		<meta charset="utf-8" />
 		<link rel="stylesheet" type="text/css" href="solarized_dark.css"/>
 		<link rel="stylesheet" type="text/css" href="application.css"/>
 


### PR DESCRIPTION
On some computers because undeclared charset, highlight.min.js parsing incorrectly while some charsets (For example, Cyrillic-1251) are toggled. Problem is going away when I manually toggling Europan or UTF-8 charset.

EDIT: Confirmed fix released here: https://github.com/seejohnrun/haste-server/issues/134