### PR TITLE
Adds Dockerfile for building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:slim
+
+# To add your own config file, mount it into the container at runtime
+#   with `docker run -v <config_file>:/src/config.js jasongwartz/haste-server`
+
+EXPOSE 7777
+COPY . /src
+WORKDIR /src
+RUN npm install
+
+CMD ["npm", "start"]
+
+


### PR DESCRIPTION
Very simple image, but it's been useful for me - deploying haste on a machine without installing node on the host. https://hub.docker.com/r/jasongwartz/haste-server/

Let me know if you're interested in including it!