### PR TITLE
removed padding for #box for correct view

### DIFF
--- a/static/application.css
+++ b/static/application.css
@@ -42,7 +42,6 @@ textarea {
 	border: 0px;
 	outline: none;
 	font-size: 13px;
-	padding-right: 360px;
   overflow: inherit;
 }
 


### PR DESCRIPTION
The view of existing snippets is wrong (a horizontal scrollbar is displayed, but there is no content on the right). This has been fixed by removing the padding-right: 360px; for #box