### PR TITLE
Upgrade testing libraries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "haste",
   "version": "0.1.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "async": {
       "version": "0.1.22",
@@ -11,7 +12,10 @@
     "async-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-cache/-/async-cache-1.0.0.tgz",
-      "integrity": "sha1-yH9tgMcrOU7g+QYe3rJNjEtiKto="
+      "integrity": "sha1-yH9tgMcrOU7g+QYe3rJNjEtiKto=",
+      "requires": {
+        "lru-cache": "2.3.1"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -23,6 +27,9 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
       "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
+      "requires": {
+        "readable-stream": "2.0.6"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -32,7 +39,15 @@
         "readable-stream": {
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44="
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
         }
       }
     },
@@ -40,7 +55,11 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -56,7 +75,11 @@
     "busboy": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.4.tgz",
-      "integrity": "sha1-GXfpbh7ohGSWUevfVIypAHWLp/M="
+      "integrity": "sha1-GXfpbh7ohGSWUevfVIypAHWLp/M=",
+      "requires": {
+        "dicer": "0.2.3",
+        "readable-stream": "1.1.14"
+      }
     },
     "colors": {
       "version": "0.6.2",
@@ -67,7 +90,10 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -78,7 +104,13 @@
     "connect": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.4.1.tgz",
-      "integrity": "sha1-ohNh0/QJnvdhzabcSpc7seuwo00="
+      "integrity": "sha1-ohNh0/QJnvdhzabcSpc7seuwo00=",
+      "requires": {
+        "debug": "2.2.0",
+        "finalhandler": "0.4.1",
+        "parseurl": "1.3.1",
+        "utils-merge": "1.0.0"
+      }
     },
     "connect-ratelimit": {
       "version": "0.0.7",
@@ -103,12 +135,19 @@
     "debug": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo="
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "requires": {
+        "ms": "0.7.1"
+      }
     },
     "dicer": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.3.tgz",
-      "integrity": "sha1-8AKBGJpVwjUe+ASQpP6fssWcSTk="
+      "integrity": "sha1-8AKBGJpVwjUe+ASQpP6fssWcSTk=",
+      "requires": {
+        "readable-stream": "1.1.14",
+        "streamsearch": "0.1.2"
+      }
     },
     "diff": {
       "version": "3.2.0",
@@ -145,7 +184,13 @@
     "finalhandler": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
-      "integrity": "sha1-haF8bFmpRxfSYtYSMNSw6+PUoU0="
+      "integrity": "sha1-haF8bFmpRxfSYtYSMNSw6+PUoU0=",
+      "requires": {
+        "debug": "2.2.0",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "unpipe": "1.0.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -162,7 +207,15 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -188,11 +241,21 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -203,66 +266,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-      "dev": true
-    },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basecreate": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
-    "lodash.create": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
     },
     "lru-cache": {
       "version": "2.3.1",
@@ -278,7 +281,10 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "0.0.8",
@@ -290,26 +296,27 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "mocha": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
-      "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
       "dev": true,
-      "dependencies": {
-        "debug": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-          "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        }
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.2.0",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
       }
     },
     "ms": {
@@ -325,13 +332,19 @@
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc="
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "packet-reader": {
       "version": "0.2.0",
@@ -352,7 +365,16 @@
     "pg": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/pg/-/pg-4.1.1.tgz",
-      "integrity": "sha1-mEgKz8089qP5Yhyl1FiUFVgqVzI="
+      "integrity": "sha1-mEgKz8089qP5Yhyl1FiUFVgqVzI=",
+      "requires": {
+        "buffer-writer": "1.0.0",
+        "generic-pool": "2.1.1",
+        "packet-reader": "0.2.0",
+        "pg-connection-string": "0.1.3",
+        "pg-types": "1.6.0",
+        "pgpass": "0.0.3",
+        "semver": "4.3.6"
+      }
     },
     "pg-connection-string": {
       "version": "0.1.3",
@@ -367,7 +389,10 @@
     "pgpass": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.3.tgz",
-      "integrity": "sha1-EuZ+NDsxicLzEgbrycwL7//PkUA="
+      "integrity": "sha1-EuZ+NDsxicLzEgbrycwL7//PkUA=",
+      "requires": {
+        "split": "0.3.3"
+      }
     },
     "pkginfo": {
       "version": "0.2.3",
@@ -382,7 +407,13 @@
     "readable-stream": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
     },
     "redis": {
       "version": "0.8.1",
@@ -392,7 +423,10 @@
     "redis-url": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/redis-url/-/redis-url-0.1.0.tgz",
-      "integrity": "sha1-TaXlsYG2wMrW4aVcf1Co5u53ebs="
+      "integrity": "sha1-TaXlsYG2wMrW4aVcf1Co5u53ebs=",
+      "requires": {
+        "redis": "0.8.1"
+      }
     },
     "request": {
       "version": "2.9.203",
@@ -404,51 +438,26 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
       "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
     },
-    "should": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/should/-/should-11.2.1.tgz",
-      "integrity": "sha1-kPVRRVUtAc/CAGZuToGKHJZw7aI=",
-      "dev": true
-    },
-    "should-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-1.0.1.tgz",
-      "integrity": "sha1-C26VFvJgGp+wuy3MNpr6HH4gCvc=",
-      "dev": true
-    },
-    "should-format": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
-      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
-      "dev": true
-    },
-    "should-type": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
-      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
-      "dev": true
-    },
-    "should-type-adaptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.0.1.tgz",
-      "integrity": "sha1-7+VVPN9oz/ZuXF9RtxLcNRx3vqo=",
-      "dev": true
-    },
-    "should-util": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
-      "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
-      "dev": true
-    },
     "split": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8="
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "requires": {
+        "through": "2.3.8"
+      }
     },
     "st": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/st/-/st-1.1.0.tgz",
-      "integrity": "sha1-c7ltsLdkTZp4zjg0o+T37G6Hz3Y="
+      "integrity": "sha1-c7ltsLdkTZp4zjg0o+T37G6Hz3Y=",
+      "requires": {
+        "async-cache": "1.0.0",
+        "bl": "1.0.3",
+        "fd": "0.0.2",
+        "graceful-fs": "4.1.11",
+        "mime": "1.3.6",
+        "negotiator": "0.6.1"
+      }
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -469,7 +478,10 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
       "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has-flag": "1.0.0"
+      }
     },
     "through": {
       "version": "2.3.8",
@@ -499,7 +511,16 @@
     "winston": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/winston/-/winston-0.6.2.tgz",
-      "integrity": "sha1-QUT+JYbNwZphK/jANVkBMskGS9I="
+      "integrity": "sha1-QUT+JYbNwZphK/jANVkBMskGS9I=",
+      "requires": {
+        "async": "0.1.22",
+        "colors": "0.6.2",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "pkginfo": "0.2.3",
+        "request": "2.9.203",
+        "stack-trace": "0.0.10"
+      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "pg": "4.1.1"
   },
   "devDependencies": {
-    "mocha": "*",
-    "should": "*"
+    "mocha": "^4.0.1"
   },
   "bundledDependencies": [],
   "engines": {
@@ -47,6 +46,6 @@
   },
   "scripts": {
     "start": "node server.js",
-    "test": "mocha -r should spec/*"
+    "test": "mocha"
   }
 }

--- a/test/document_handler_spec.js
+++ b/test/document_handler_spec.js
@@ -1,5 +1,7 @@
 /* global describe, it */
 
+var assert = require('assert');
+
 var DocumentHandler = require('../lib/document_handler');
 var Generator = require('../lib/key_generators/random');
 
@@ -10,13 +12,13 @@ describe('document_handler', function() {
     it('should choose a key of the proper length', function() {
       var gen = new Generator();
       var dh = new DocumentHandler({ keyLength: 6, keyGenerator: gen });
-      dh.acceptableKey().length.should.equal(6);
+      assert.equal(6, dh.acceptableKey().length);
     });
 
     it('should choose a default key length', function() {
       var gen = new Generator();
       var dh = new DocumentHandler({ keyGenerator: gen });
-      dh.keyLength.should.equal(DocumentHandler.defaultKeyLength);
+      assert.equal(dh.keyLength, DocumentHandler.defaultKeyLength);
     });
 
   });

--- a/test/redis_document_store_spec.js
+++ b/test/redis_document_store_spec.js
@@ -1,9 +1,11 @@
 /* global it, describe, afterEach */
 
-var RedisDocumentStore = require('../lib/document_stores/redis');
+var assert = require('assert');
 
 var winston = require('winston');
 winston.remove(winston.transports.Console);
+
+var RedisDocumentStore = require('../lib/document_stores/redis');
 
 describe('redis_document_store', function() {
 
@@ -21,7 +23,7 @@ describe('redis_document_store', function() {
       var store = new RedisDocumentStore({ expire: 10 });
       store.set('hello1', 'world', function() {
         RedisDocumentStore.client.ttl('hello1', function(err, res) {
-          res.should.be.above(1);
+          assert.ok(res > 1);
           done();
         });
       });
@@ -31,7 +33,7 @@ describe('redis_document_store', function() {
       var store = new RedisDocumentStore({ expire: 10 });
       store.set('hello2', 'world', function() {
         RedisDocumentStore.client.ttl('hello2', function(err, res) {
-          res.should.equal(-1);
+          assert.equal(-1, res);
           done();
         });
       }, true);
@@ -41,7 +43,7 @@ describe('redis_document_store', function() {
       var store = new RedisDocumentStore({ expire: false });
       store.set('hello3', 'world', function() {
         RedisDocumentStore.client.ttl('hello3', function(err, res) {
-          res.should.equal(-1);
+          assert.equal(-1, res);
           done();
         });
       });


### PR DESCRIPTION
- Upgrade mocha
- Remove should due to limited usage and old style (at least by rspec standards)
- Move spec -> test which is the default
- Update tests accordingly for the above