### PR TITLE
Add CORS response header for raw get path

### DIFF
--- a/lib/document_handler.js
+++ b/lib/document_handler.js
@@ -36,7 +36,7 @@ DocumentHandler.prototype.handleRawGet = function(key, response, skipExpire) {
   this.store.get(key, function(ret) {
     if (ret) {
       winston.verbose('retrieved raw document', { key: key });
-      response.writeHead(200, { 'content-type': 'text/plain' });
+      response.writeHead(200, { 'content-type': 'text/plain', 'Access-Control-Allow-Origin': '*' });
       response.end(ret);
     }
     else {


### PR DESCRIPTION
Allows clients to read paste data from a different origin.

https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS