### PR TITLE
Update docs to real defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ STDOUT.  Check the README there for more details and usages.
 * `host` - the host the server runs on (default localhost)
 * `port` - the port the server runs on (default 7777)
 * `keyLength` - the length of the keys to user (default 10)
-* `maxLength` - maximum length of a paste (default none)
+* `maxLength` - maximum length of a paste (default 400000)
 * `staticMaxAge` - max age for static assets (86400)
 * `recompressStaticAssets` - whether or not to compile static js assets (true)
 * `documents` - static documents to serve (ex: http://hastebin.com/about.com)


### PR DESCRIPTION
Seems like docs are wrong, as this is the default. 

https://github.com/seejohnrun/haste-server/blob/master/config.js#L8