### PR TITLE
Update configuration file naming and default storage method

### DIFF
--- a/config.json
+++ b/config.json
@@ -33,10 +33,8 @@
   },
 
   "storage": {
-    "type": "memcached",
-    "host": "127.0.0.1",
-    "port": 11211,
-    "expire": 2592000
+    "path": "./data",
+    "type": "file"
   },
 
   "documents": {

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ var connect_rate_limit = require('connect-ratelimit');
 var DocumentHandler = require('./lib/document_handler');
 
 // Load the configuration and set some defaults
-var config = JSON.parse(fs.readFileSync('./config.js', 'utf8'));
+var config = JSON.parse(fs.readFileSync('./config.json', 'utf8'));
 config.port = process.env.PORT || config.port || 7777;
 config.host = process.env.HOST || config.host || 'localhost';
 


### PR DESCRIPTION
The config.js file has been renamed to config.json as to allow multi-file editors such as Visual Studio Code and Notepad++ to read the file's syntax and errors correctly, as they rely on the file type extension for this.

Also updated the default storage method in the config to match the default storage method documented on the README.md, as the existing storage method crashes haste-server if users do not realised they need to install memcached, and still does not work if the users also do not realise they need to be running a memcached server. This change allows haste-server's config to match it's documented README.md and also work successfully out of the box.