### PR TITLE
Add an Amazon S3 document store

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,27 @@ Also, you must create an `uploads` table, which will store all the data for uplo
 
 You can optionally add the `user` and `password` properties to use a user system.
 
+### Amazon S3
+
+To use [Amazon S3](https://aws.amazon.com/s3/) as a storage system, you must
+install the `aws-sdk` package via npm:
+
+`npm install aws-sdk`
+
+Once you've done that, your config section should look like this:
+
+```json
+{
+  "type": "amazon-s3",
+  "bucket": "your-bucket-name",
+  "region": "us-east-1"
+}
+```
+
+Authentication is handled automatically by the client. Check
+[Amazon's documentation](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html)
+for more information.
+
 ## Author
 
 John Crepezzi <john.crepezzi@gmail.com>

--- a/README.md
+++ b/README.md
@@ -217,7 +217,24 @@ Once you've done that, your config section should look like this:
 
 Authentication is handled automatically by the client. Check
 [Amazon's documentation](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html)
-for more information.
+for more information. You will need to grant your role these permissions to
+your bucket:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject"
+            ],
+            "Effect": "Allow",
+            "Resource": "arn:aws:s3:::your-bucket-name-goes-here/*"
+        }
+    ]
+}
+```
 
 ## Author
 

--- a/lib/document_stores/amazon-s3.js
+++ b/lib/document_stores/amazon-s3.js
@@ -1,0 +1,56 @@
+/*global require,module,process*/
+
+var AWS = require('aws-sdk');
+var winston = require('winston');
+
+var AmazonS3DocumentStore = function(options) {
+  this.expire = options.expire;
+  this.bucket = options.bucket;
+  this.client = new AWS.S3({region: options.region});
+};
+
+AmazonS3DocumentStore.prototype.get = function(key, callback, skipExpire) {
+  var _this = this;
+
+  var req = {
+    Bucket: _this.bucket,
+    Key: key
+  };
+
+  _this.client.getObject(req, function(err, data) {
+    if(err) {
+      callback(false);
+    }
+    else {
+      callback(data.Body.toString('utf-8'));
+      if (_this.expire && !skipExpire) {
+        winston.warn('amazon s3 store cannot set expirations on keys');
+      }
+    }
+  });
+}
+
+AmazonS3DocumentStore.prototype.set = function(key, data, callback, skipExpire) {
+  var _this = this;
+
+  var req = {
+    Bucket: _this.bucket,
+    Key: key,
+    Body: data,
+    ContentType: 'text/plain'
+  };
+
+  _this.client.putObject(req, function(err, data) {
+    if (err) {
+      callback(false);
+    }
+    else {
+      callback(true);
+      if (_this.expire && !skipExpire) {
+        winston.warn('amazon s3 store cannot set expirations on keys');
+      }
+    }
+  });
+}
+
+module.exports = AmazonS3DocumentStore;


### PR DESCRIPTION
Hey! This is a basic backend that uses S3.

Expiration isn't supported (I could look into that in a follow-up) and the only way AWS credentials can be used is via the default (recommended) means, vs. e.g. specifying them in config.json (which I think is probably not worth supporting.)

We are using this in production. Code-style wise, I modeled this off the file backend.