### PR TITLE
upgrade npm package version to 5.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "redis": "0.8.1",
     "uglify-js": "3.1.6",
     "busboy": "0.2.4",
-    "pg": "4.1.1"
+    "pg": "5.2.1"
   },
   "devDependencies": {
     "mocha": "^4.0.1"


### PR DESCRIPTION
Errors occured with previous version 4.1.1 and versions >5

when pg<5: `error: error connecting to postgres name=error, length=104, severity=FATAL, code=28P01, detail=undefined, hint=undefined, position=undefined, internalPosition=undefined, internalQuery=undefined, where=undefined, file=auth.c, line=328, routine=auth_failed`
when pg>5: `(node:28) DeprecationWarning: PG.connect is deprecated - please see the upgrade guide at https://node-postgres.com/guides/upgrading
verbose: added document key=caturosoke`