### PR TITLE
add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:alpine3.10
+COPY . /srv
+WORKDIR /srv
+RUN npm install
+CMD "npm" "start"

--- a/README.md
+++ b/README.md
@@ -22,11 +22,20 @@ STDOUT.  Check the README there for more details and usages.
 
 ## Tested Browsers
 
-* Firefox 8
+* Firefox 74
 * Chrome 17
 * Safari 5.3
 
-## Installation
+## Docker installation
+
+`docker build -t haste .`
+
+`docker run -ti -p 7777:7777 haste`
+
+open your browser to localhost:7777
+
+
+## Manual Installation
 
 1.  Download the package, and expand it
 2.  Explore the settings inside of config.js, but the defaults should be good

--- a/config.js
+++ b/config.js
@@ -33,10 +33,8 @@
   },
 
   "storage": {
-    "type": "memcached",
-    "host": "127.0.0.1",
-    "port": 11211,
-    "expire": 2592000
+    "type": "file",
+    "path": "./data"
   },
 
   "documents": {


### PR DESCRIPTION
Hello,
I added a minimalistic Dockerfile to build a container image from this repo.

I edited the sample config.js to use the file storage instead of relying on memcached, this is to simplify the container build and get up&running without any components. Of course it is not the recommended way for a seriuos installation (containers are ephermal). Maybe we can specify in the config file this aspect.

I added some notes in the Readme, the browser supported version need an update too :)