### PR TITLE
remove 1px margin from textarea, fixes useless scrollbar

### DIFF
--- a/static/application.css
+++ b/static/application.css
@@ -17,6 +17,8 @@ textarea {
 	outline: none;
 	resize: none;
 	font-size: 13px;
+	margin-top: 0;
+	margin-bottom: 0;
 }
 
 /* the line numbers */


### PR DESCRIPTION
For some reason the textarea has a 1px margin on the top and bottom, causing the page to have a scrollbar that does absolutely nothing. this just removes the extra height so the page looks a bit better.