### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start server.js"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Haste
-
+[![Run on Repl.it](https://repl.it/badge/github/seejohnrun/haste-server)](https://repl.it/github/seejohnrun/haste-server)
 Haste is an open-source pastebin software written in node.js, which is easily
 installable in any network.  It can be backed by either redis or filesystem,
 and has a very easy adapter interface for other stores.  A publicly available


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).