### PR TITLE
Fix memcached client fetch for key not found

### DIFF
--- a/lib/document_stores/memcached.js
+++ b/lib/document_stores/memcached.js
@@ -26,7 +26,7 @@ class MemcachedDocumentStore {
 
   // Save file in a key
   set(key, data, callback, skipExpire) {
-    this.client.set(key, data, skipExpire ? 0 : this.expire, (error) => {
+    this.client.set(key, data, skipExpire ? 0 : this.expire || 0, (error) => {
       callback(!error);
     });
   }
@@ -34,10 +34,12 @@ class MemcachedDocumentStore {
   // Get a file from a key
   get(key, callback, skipExpire) {
     this.client.get(key, (error, data) => {
-      callback(error ? false : data);
+      const value = error ? false : data;
+
+      callback(value);
 
       // Update the key so that the expiration is pushed forward
-      if (!skipExpire) {
+      if (value && !skipExpire) {
         this.set(key, data, (updateSucceeded) => {
           if (!updateSucceeded) {
             winston.error('failed to update expiration on GET', {key});


### PR DESCRIPTION
The memcached client wasn't correctly handling looking up a key that
didn't exist.  Now we only try to push the expiration forward if there
is actually a value in memcached.

Also while I'm in here, allow expiration to be left blank.

Closes #284
Closes #279
Closes #273 
